### PR TITLE
fix: path escaping in vercel-ignore-build.sh

### DIFF
--- a/scripts/test-vercel-ignore-build.sh
+++ b/scripts/test-vercel-ignore-build.sh
@@ -57,6 +57,49 @@ echo ""
 
 cd "$PROJECT_ROOT"
 
+# Test 0: Validate sed pattern escaping logic
+echo "========================================"
+echo "Test 0: Sed Pattern Escaping"
+echo "========================================"
+echo "Testing that the sed pattern correctly escapes special regex metacharacters..."
+echo ""
+
+# Test paths with various special characters
+test_sed_pattern() {
+  local test_path="$1"
+  local description="$2"
+  
+  # Use the exact sed pattern from vercel-ignore-build.sh
+  local escaped=$(printf '%s\n' "$test_path" | sed 's|[][\.*^$/]|\\&|g')
+  
+  # Verify the escaped pattern matches the original
+  if echo "$test_path" | grep -qE "^${escaped}\$"; then
+    echo -e "${GREEN}✓ PASS${NC} - $description: '$test_path' -> '$escaped'"
+    TESTS_PASSED=$((TESTS_PASSED + 1))
+    return 0
+  else
+    echo -e "${RED}✗ FAIL${NC} - $description: '$test_path' escaped to '$escaped' but doesn't match"
+    TESTS_FAILED=$((TESTS_FAILED + 1))
+    return 1
+  fi
+}
+
+# Test various special characters that might appear in file paths
+test_sed_pattern "app/" "Directory with slash"
+test_sed_pattern "lib/" "Another directory"
+test_sed_pattern "test.config.js" "File with dots"
+test_sed_pattern "file.test.ts" "File with multiple dots"
+test_sed_pattern "[special].txt" "File with brackets"
+test_sed_pattern "test-[version].json" "File with brackets in middle"
+test_sed_pattern "path/to/file.js" "Nested path with slashes"
+test_sed_pattern "test*pattern.md" "File with asterisk"
+test_sed_pattern "test^marker.txt" "File with caret"
+test_sed_pattern 'test$var.sh' "File with dollar sign"
+
+echo ""
+echo "Sed pattern escaping tests completed."
+echo ""
+
 # Ensure we have git history
 if ! git rev-parse HEAD~1 >/dev/null 2>&1; then
   echo -e "${RED}Error: Need at least 2 commits in git history to run tests${NC}"

--- a/scripts/vercel-ignore-build.sh
+++ b/scripts/vercel-ignore-build.sh
@@ -106,14 +106,14 @@ echo ""
 for path in "${BUILD_PATHS[@]}"; do
   if [[ "$path" == */ ]]; then
     # Directory: match any file under this directory
-    if echo "$CHANGED_FILES" | grep -qE "^$(printf '%s\n' "$path" | sed 's/[].*^$\/[]/\\&/g')"; then
+    if echo "$CHANGED_FILES" | grep -qE "^$(printf '%s\n' "$path" | sed 's|[][\.*^$/]|\\&|g')"; then
       echo "✓ Build-impacting path changed: $path"
       echo "Building."
       exit 1
     fi
   else
     # File: match only the exact file at the root
-    if echo "$CHANGED_FILES" | grep -qE "^$(printf '%s\n' "$path" | sed 's/[].*^$\/[]/\\&/g')\$"; then
+    if echo "$CHANGED_FILES" | grep -qE "^$(printf '%s\n' "$path" | sed 's|[][\.*^$/]|\\&|g')\$"; then
       echo "✓ Build-impacting path changed: $path"
       echo "Building."
       exit 1


### PR DESCRIPTION
## Summary

Improves the escaping of special regex characters in build-impacting paths when matching changed files, ensuring correct detection of changes for both directories and files.

## Type of Change

- [x] `fix` — Bug fix

> **Note**: Changes limited to documentation (`docs/`, `README.md`, etc.) or tests will skip Vercel builds automatically. See [docs/DEPLOYMENT.md](../docs/DEPLOYMENT.md) for details.

## Technical Governance Compliance

- [x] Follows [Engineering Standards](../docs/ENGINEERING_STANDARDS.md)
- [x] Follows [Architecture](../docs/ARCHITECTURE.md) guidelines
- [x] Follows [Technical Governance](https://vicenteopaso.com/technical-governance) principles
- [x] Aligns with the SDD (`/sdd.yaml`) or updates it in this PR
- [x] Documentation updated in `docs/` (if applicable)
- [ ] Component documentation added/updated (if applicable)
- [ ] README updated (if behavior changes)

## Quality Checks

- [x] `pnpm lint` passes
- [x] `pnpm typecheck` passes
- [x] `pnpm test` passes with adequate coverage
- [x] `pnpm test:e2e` passes (if UI/routing changes)
- [ ] Visual tests updated if UI changed (`pnpm test:visual:update`)

## Additional Verification

- [ ] Cross-browser testing completed (if UI changes)
- [ ] Accessibility verified (keyboard nav, screen reader, ARIA)
- [ ] Performance impact considered (bundle size, Core Web Vitals)
- [ ] Security review completed (no secrets, proper input validation)
- [ ] SEO metadata updated (if content/routing changes)
