### PR TITLE
fix: regex escaping in build path matching script

### DIFF
--- a/scripts/test-vercel-ignore-build.sh
+++ b/scripts/test-vercel-ignore-build.sh
@@ -70,7 +70,7 @@ test_sed_pattern() {
   local description="$2"
   
   # Use the exact sed pattern from vercel-ignore-build.sh
-  local escaped=$(printf '%s\n' "$test_path" | sed 's|[][\.*^$/]|\\&|g')
+  local escaped=$(printf '%s\n' "$test_path" | sed 's|[].[*^$[]|\\&|g')
   
   # Verify the escaped pattern matches the original
   if echo "$test_path" | grep -qE "^${escaped}\$"; then

--- a/scripts/vercel-ignore-build.sh
+++ b/scripts/vercel-ignore-build.sh
@@ -105,7 +105,7 @@ echo ""
 # Check if any build-triggering path was modified
 for path in "${BUILD_PATHS[@]}"; do
   # Escape regex special characters (but NOT forward slash, it's not special in grep)
-  escaped_path=$(printf '%s\n' "$path" | sed 's/[][\.*^$]/\\&/g')
+  escaped_path=$(printf '%s\n' "$path" | sed 's/[].[*^$[]/\\&/g')
   
   if [[ "$path" == */ ]]; then
     # Directory: match any file under this directory


### PR DESCRIPTION
## Summary

Improves escaping of regex special characters in build path matching within vercel-ignore-build.sh. Ensures correct detection of changed files and directories by properly escaping characters for grep.

## Type of Change

- [x] `fix` — Bug fix

> **Note**: Changes limited to documentation (`docs/`, `README.md`, etc.) or tests will skip Vercel builds automatically. See [docs/DEPLOYMENT.md](../docs/DEPLOYMENT.md) for details.

## Technical Governance Compliance

- [x] Follows [Engineering Standards](../docs/ENGINEERING_STANDARDS.md)
- [x] Follows [Architecture](../docs/ARCHITECTURE.md) guidelines
- [x] Follows [Technical Governance](https://vicenteopaso.com/technical-governance) principles
- [x] Aligns with the SDD (`/sdd.yaml`) or updates it in this PR
- [x] Documentation updated in `docs/` (if applicable)
- [ ] Component documentation added/updated (if applicable)
- [ ] README updated (if behavior changes)

## Quality Checks

- [x] `pnpm lint` passes
- [x] `pnpm typecheck` passes
- [x] `pnpm test` passes with adequate coverage
- [x] `pnpm test:e2e` passes (if UI/routing changes)
- [ ] Visual tests updated if UI changed (`pnpm test:visual:update`)

## Additional Verification

- [ ] Cross-browser testing completed (if UI changes)
- [ ] Accessibility verified (keyboard nav, screen reader, ARIA)
- [ ] Performance impact considered (bundle size, Core Web Vitals)
- [ ] Security review completed (no secrets, proper input validation)
- [ ] SEO metadata updated (if content/routing changes)
