### PR TITLE
feat: Add locale-based redirect for the profile API route

### DIFF
--- a/app/api/profile/route.ts
+++ b/app/api/profile/route.ts
@@ -1,0 +1,18 @@
+import { NextResponse } from "next/server";
+
+export const dynamic = "force-static";
+
+function getPreferredProfileLocale(request: Request): "en" | "es" {
+  const langHeader = request.headers.get("accept-language") || "";
+  const preferredLang = langHeader.split(",")[0]?.slice(0, 2) || "";
+
+  return preferredLang === "es" ? "es" : "en";
+}
+
+export async function GET(request: Request) {
+  const locale = getPreferredProfileLocale(request);
+  const url = new URL(request.url);
+  url.pathname = `/api/profile/${locale}`;
+
+  return NextResponse.redirect(url, { status: 307 });
+}

--- a/app/api/profile/route.ts
+++ b/app/api/profile/route.ts
@@ -1,6 +1,6 @@
 import { NextResponse } from "next/server";
 
-export const dynamic = "force-static";
+export const dynamic = "force-dynamic";
 
 function getPreferredProfileLocale(request: Request): "en" | "es" {
   const langHeader = request.headers.get("accept-language") || "";

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -2946,8 +2946,8 @@ packages:
     resolution: {integrity: sha512-3XSA2cR/h/73EzlXXdU6YNycmYI7+kicTxks4eJg2g39biHR84slg2+des+p7iHYhbRg/udIS4TD53WabcOUkw==}
     engines: {node: '>= 0.4'}
 
-  baseline-browser-mapping@2.10.12:
-    resolution: {integrity: sha512-qyq26DxfY4awP2gIRXhhLWfwzwI+N5Nxk6iQi8EFizIaWIjqicQTE4sLnZZVdeKPRcVNoJOkkpfzoIYuvCKaIQ==}
+  baseline-browser-mapping@2.10.13:
+    resolution: {integrity: sha512-BL2sTuHOdy0YT1lYieUxTw/QMtPBC3pmlJC6xk8BBYVv6vcw3SGdKemQ+Xsx9ik2F/lYDO9tqsFQH1r9PFuHKw==}
     engines: {node: '>=6.0.0'}
     hasBin: true
 
@@ -9098,7 +9098,7 @@ snapshots:
 
   base64-js@0.0.8: {}
 
-  baseline-browser-mapping@2.10.12: {}
+  baseline-browser-mapping@2.10.13: {}
 
   basic-ftp@5.2.0: {}
 
@@ -9140,7 +9140,7 @@ snapshots:
 
   browserslist@4.28.2:
     dependencies:
-      baseline-browser-mapping: 2.10.12
+      baseline-browser-mapping: 2.10.13
       caniuse-lite: 1.0.30001782
       electron-to-chromium: 1.5.329
       node-releases: 2.0.36
@@ -11737,7 +11737,7 @@ snapshots:
     dependencies:
       '@next/env': 16.2.1
       '@swc/helpers': 0.5.15
-      baseline-browser-mapping: 2.10.12
+      baseline-browser-mapping: 2.10.13
       caniuse-lite: 1.0.30001782
       postcss: 8.4.31
       react: 19.2.4

--- a/public/sitemap-0.xml
+++ b/public/sitemap-0.xml
@@ -1,17 +1,18 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <urlset xmlns="http://www.sitemaps.org/schemas/sitemap/0.9" xmlns:news="http://www.google.com/schemas/sitemap-news/0.9" xmlns:xhtml="http://www.w3.org/1999/xhtml" xmlns:mobile="http://www.google.com/schemas/sitemap-mobile/1.0" xmlns:image="http://www.google.com/schemas/sitemap-image/1.1" xmlns:video="http://www.google.com/schemas/sitemap-video/1.1">
-<url><loc>https://opa.so/en</loc><lastmod>2026-03-31T14:06:53.099Z</lastmod><changefreq>monthly</changefreq><priority>0.7</priority></url>
-<url><loc>https://opa.so/en/accessibility</loc><lastmod>2026-03-31T14:06:53.100Z</lastmod><changefreq>monthly</changefreq><priority>0.7</priority></url>
-<url><loc>https://opa.so/en/cookie-policy</loc><lastmod>2026-03-31T14:06:53.100Z</lastmod><changefreq>monthly</changefreq><priority>0.7</priority></url>
-<url><loc>https://opa.so/en/cv</loc><lastmod>2026-03-31T14:06:53.100Z</lastmod><changefreq>monthly</changefreq><priority>0.7</priority></url>
-<url><loc>https://opa.so/en/privacy-policy</loc><lastmod>2026-03-31T14:06:53.100Z</lastmod><changefreq>monthly</changefreq><priority>0.7</priority></url>
-<url><loc>https://opa.so/en/tech-stack</loc><lastmod>2026-03-31T14:06:53.100Z</lastmod><changefreq>monthly</changefreq><priority>0.7</priority></url>
-<url><loc>https://opa.so/en/technical-governance</loc><lastmod>2026-03-31T14:06:53.100Z</lastmod><changefreq>monthly</changefreq><priority>0.7</priority></url>
-<url><loc>https://opa.so/es</loc><lastmod>2026-03-31T14:06:53.100Z</lastmod><changefreq>monthly</changefreq><priority>0.7</priority></url>
-<url><loc>https://opa.so/es/accessibility</loc><lastmod>2026-03-31T14:06:53.100Z</lastmod><changefreq>monthly</changefreq><priority>0.7</priority></url>
-<url><loc>https://opa.so/es/cookie-policy</loc><lastmod>2026-03-31T14:06:53.100Z</lastmod><changefreq>monthly</changefreq><priority>0.7</priority></url>
-<url><loc>https://opa.so/es/cv</loc><lastmod>2026-03-31T14:06:53.100Z</lastmod><changefreq>monthly</changefreq><priority>0.7</priority></url>
-<url><loc>https://opa.so/es/privacy-policy</loc><lastmod>2026-03-31T14:06:53.100Z</lastmod><changefreq>monthly</changefreq><priority>0.7</priority></url>
-<url><loc>https://opa.so/es/tech-stack</loc><lastmod>2026-03-31T14:06:53.100Z</lastmod><changefreq>monthly</changefreq><priority>0.7</priority></url>
-<url><loc>https://opa.so/es/technical-governance</loc><lastmod>2026-03-31T14:06:53.100Z</lastmod><changefreq>monthly</changefreq><priority>0.7</priority></url>
+<url><loc>https://opa.so/api/profile</loc><lastmod>2026-03-31T15:44:10.766Z</lastmod><changefreq>monthly</changefreq><priority>0.7</priority></url>
+<url><loc>https://opa.so/en</loc><lastmod>2026-03-31T15:44:10.767Z</lastmod><changefreq>monthly</changefreq><priority>0.7</priority></url>
+<url><loc>https://opa.so/en/accessibility</loc><lastmod>2026-03-31T15:44:10.767Z</lastmod><changefreq>monthly</changefreq><priority>0.7</priority></url>
+<url><loc>https://opa.so/en/cookie-policy</loc><lastmod>2026-03-31T15:44:10.767Z</lastmod><changefreq>monthly</changefreq><priority>0.7</priority></url>
+<url><loc>https://opa.so/en/cv</loc><lastmod>2026-03-31T15:44:10.767Z</lastmod><changefreq>monthly</changefreq><priority>0.7</priority></url>
+<url><loc>https://opa.so/en/privacy-policy</loc><lastmod>2026-03-31T15:44:10.767Z</lastmod><changefreq>monthly</changefreq><priority>0.7</priority></url>
+<url><loc>https://opa.so/en/tech-stack</loc><lastmod>2026-03-31T15:44:10.767Z</lastmod><changefreq>monthly</changefreq><priority>0.7</priority></url>
+<url><loc>https://opa.so/en/technical-governance</loc><lastmod>2026-03-31T15:44:10.767Z</lastmod><changefreq>monthly</changefreq><priority>0.7</priority></url>
+<url><loc>https://opa.so/es</loc><lastmod>2026-03-31T15:44:10.767Z</lastmod><changefreq>monthly</changefreq><priority>0.7</priority></url>
+<url><loc>https://opa.so/es/accessibility</loc><lastmod>2026-03-31T15:44:10.767Z</lastmod><changefreq>monthly</changefreq><priority>0.7</priority></url>
+<url><loc>https://opa.so/es/cookie-policy</loc><lastmod>2026-03-31T15:44:10.767Z</lastmod><changefreq>monthly</changefreq><priority>0.7</priority></url>
+<url><loc>https://opa.so/es/cv</loc><lastmod>2026-03-31T15:44:10.767Z</lastmod><changefreq>monthly</changefreq><priority>0.7</priority></url>
+<url><loc>https://opa.so/es/privacy-policy</loc><lastmod>2026-03-31T15:44:10.767Z</lastmod><changefreq>monthly</changefreq><priority>0.7</priority></url>
+<url><loc>https://opa.so/es/tech-stack</loc><lastmod>2026-03-31T15:44:10.767Z</lastmod><changefreq>monthly</changefreq><priority>0.7</priority></url>
+<url><loc>https://opa.so/es/technical-governance</loc><lastmod>2026-03-31T15:44:10.767Z</lastmod><changefreq>monthly</changefreq><priority>0.7</priority></url>
 </urlset>

--- a/test/unit/profile-route.test.ts
+++ b/test/unit/profile-route.test.ts
@@ -1,6 +1,7 @@
-import { describe, expect, it } from "vitest";
+import { describe, expect, it, vi } from "vitest";
 
 async function createGetHandler() {
+  vi.resetModules();
   const mod = await import("../../app/api/profile/route");
   return mod.GET as (req: Request) => Promise<Response>;
 }

--- a/test/unit/profile-route.test.ts
+++ b/test/unit/profile-route.test.ts
@@ -1,0 +1,47 @@
+import { describe, expect, it } from "vitest";
+
+async function createGetHandler() {
+  const mod = await import("../../app/api/profile/route");
+  return mod.GET as (req: Request) => Promise<Response>;
+}
+
+describe("app/api/profile GET", () => {
+  it("redirects Spanish browsers to /api/profile/es", async () => {
+    const GET = await createGetHandler();
+
+    const res = await GET(
+      new Request("http://localhost/api/profile", {
+        headers: {
+          "accept-language": "es-ES,es;q=0.9",
+        },
+      }),
+    );
+
+    expect(res.status).toBe(307);
+    expect(res.headers.get("location")).toBe("http://localhost/api/profile/es");
+  });
+
+  it("redirects non-Spanish browsers to /api/profile/en", async () => {
+    const GET = await createGetHandler();
+
+    const res = await GET(
+      new Request("http://localhost/api/profile", {
+        headers: {
+          "accept-language": "en-US,en;q=0.9",
+        },
+      }),
+    );
+
+    expect(res.status).toBe(307);
+    expect(res.headers.get("location")).toBe("http://localhost/api/profile/en");
+  });
+
+  it("defaults to /api/profile/en when the header is missing", async () => {
+    const GET = await createGetHandler();
+
+    const res = await GET(new Request("http://localhost/api/profile"));
+
+    expect(res.status).toBe(307);
+    expect(res.headers.get("location")).toBe("http://localhost/api/profile/en");
+  });
+});


### PR DESCRIPTION
## Summary
- add `/api/profile` to redirect to the locale-specific profile endpoint based on the `accept-language` header
- default to English when the header is missing or not Spanish
- cover Spanish, non-Spanish, and missing-header cases with unit tests

## Testing
- Not run (not requested)

## Type of Change
## Architecture Decision Record (ADR)
## Technical Governance Compliance
## Quality Checks
## AI Guardrails Compliance
## Additional Verification