### PR TITLE
fix: preserve OG image across all static routes

### DIFF
--- a/lib/seo.ts
+++ b/lib/seo.ts
@@ -54,7 +54,20 @@ export function baseMetadata(overrides: Partial<Metadata> = {}): Metadata {
     },
   };
 
-  return { ...base, ...overrides };
+  const { openGraph: overrideOg, twitter: overrideTwitter, ...restOverrides } = overrides;
+
+  return {
+    ...base,
+    ...restOverrides,
+    openGraph: {
+      ...base.openGraph,
+      ...overrideOg,
+    },
+    twitter: {
+      ...base.twitter,
+      ...overrideTwitter,
+    },
+  };
 }
 
 export function getWebsiteJsonLd() {

--- a/lib/seo.ts
+++ b/lib/seo.ts
@@ -60,12 +60,12 @@ export function baseMetadata(overrides: Partial<Metadata> = {}): Metadata {
     ...base,
     ...restOverrides,
     openGraph: {
-      ...base.openGraph,
-      ...overrideOg,
+      ...(base.openGraph ?? {}),
+      ...(overrideOg ?? {}),
     },
     twitter: {
-      ...base.twitter,
-      ...overrideTwitter,
+      ...(base.twitter ?? {}),
+      ...(overrideTwitter ?? {}),
     },
   };
 }

--- a/test/unit/seo.test.ts
+++ b/test/unit/seo.test.ts
@@ -16,6 +16,37 @@ describe("seo utilities", () => {
     expect(metadata.title).toBe("Custom Title");
   });
 
+  it("preserves openGraph images when overriding only title and description", async () => {
+    vi.resetModules();
+    const { baseMetadata } = await import("../../lib/seo");
+    const metadata = baseMetadata({
+      openGraph: {
+        title: "Custom OG Title",
+        description: "Custom OG description",
+      },
+    });
+
+    const images = metadata.openGraph?.images as { url: string }[];
+    expect(images).toBeDefined();
+    expect(images.length).toBeGreaterThan(0);
+    expect(images[0].url).toContain("opengraph-image");
+    expect(metadata.openGraph?.title).toBe("Custom OG Title");
+  });
+
+  it("preserves twitter images when overriding only title", async () => {
+    vi.resetModules();
+    const { baseMetadata } = await import("../../lib/seo");
+    const metadata = baseMetadata({
+      twitter: { title: "Custom Twitter Title" },
+    });
+
+    const images = metadata.twitter?.images as string[];
+    expect(images).toBeDefined();
+    expect(images.length).toBeGreaterThan(0);
+    expect(String(images[0])).toContain("opengraph-image");
+    expect(metadata.twitter?.title).toBe("Custom Twitter Title");
+  });
+
   it("uses default og cache version when env is unset", async () => {
     const originalEnv = process.env.NEXT_PUBLIC_OG_CACHE_DATE;
     delete process.env.NEXT_PUBLIC_OG_CACHE_DATE;


### PR DESCRIPTION
## Summary

`baseMetadata()` in `lib/seo.ts` was doing a flat `{ ...base, ...overrides }` spread. When any page passed `openGraph: { title, description }` as a partial override, the entire `openGraph` object was replaced — discarding `images`, `type`, `url`, and `siteName` from the base.

This meant only the homepage (`/[lang]/opengraph-image.tsx`) and `/cv` (which has its own `opengraph-image.tsx` file) were serving OG images. All other static routes (`/tech-stack`, `/privacy-policy`, `/cookie-policy`, `/accessibility`, `/technical-governance`) had no `og:image` or `twitter:image` tag.

**Fix:** Destructure `openGraph` and `twitter` from `overrides` before spreading, then shallow-merge each into their base counterpart so `images` (and other base fields) are always preserved.

## Related Issue

N/A

## Type of Change

- [ ] `feat` — New feature or enhancement
- [x] `fix` — Bug fix
- [ ] `chore` — Maintenance, dependencies, or configuration
- [ ] `docs` — Documentation only
- [ ] `refactor` — Code refactoring without behavior change
- [ ] `test` — Adding or updating tests

## Architecture Decision Record (ADR)

**Architecture Change?**

- [ ] Yes (add `architecture-change` label and link ADR above)
- [x] No

## Technical Governance Compliance

- [x] Complies with the supreme invariants in [Constitution](../docs/CONSTITUTION.md)
- [x] Follows [Engineering Standards](../docs/ENGINEERING_STANDARDS.md)
- [x] Follows [Architecture](../docs/ARCHITECTURE.md) guidelines
- [x] Follows [Technical Governance](https://vicenteopaso.com/technical-governance) principles
- [x] Aligns with the SDD (`/sdd.yaml`) or updates it in this PR
- [ ] Documentation updated in `docs/` (if applicable)
- [ ] Component documentation added/updated (if applicable)
- [ ] README updated (if behavior changes)

## AI Governance (if applicable)

- [x] Reviewed [AI Guardrails](../docs/AI_GUARDRAILS.md) — Security constraints respected
- [x] Reviewed [Forbidden Patterns](../docs/FORBIDDEN_PATTERNS.md) — No anti-patterns introduced
- [x] Completed [Review Checklist](../docs/REVIEW_CHECKLIST.md) — All applicable items verified
- [x] Security controls maintained (Turnstile, rate limiting, input validation, HTML sanitization)
- [x] No secrets or credentials hard-coded
- [x] Accessibility standards maintained (WCAG 2.1 AA)
- [x] Architecture boundaries respected (no cross-layer imports)

## Quality Checks

- [x] `pnpm lint` passes
- [x] `pnpm typecheck` passes
- [x] `pnpm test` passes with adequate coverage
- [ ] `pnpm test:e2e` passes (if UI/routing changes)
- [ ] Visual tests updated if UI changed (`pnpm test:visual:update`)
- [x] Reviewed changes against [Code Review Checklist](../docs/REVIEW_CHECKLIST.md)

## CI/CD

- [x] All required checks pass (lint, typecheck, test, coverage, build, a11y, security, Lighthouse)

## AI Guardrails Compliance

- [x] Tests added/updated for code changes (unit, e2e, or visual)
- [x] Error handling verified and follows [Error Handling Guide](../docs/ERROR_HANDLING.md)
- [x] Accessibility verified (keyboard navigation, ARIA, focus management)
- [x] SEO impact assessed and metadata updated if needed
- [x] Security considerations reviewed (input validation, XSS prevention)

## Additional Verification

- [ ] Cross-browser testing completed (if UI changes)
- [x] Performance impact considered (bundle size, Core Web Vitals)
- [ ] Mobile responsiveness verified (if UI changes)

## Additional Notes

Pure metadata fix — no runtime behavior, UI, or routing changes. Only `lib/seo.ts` and its unit tests are touched.