### PR TITLE
fix: contain fake-timer leak and effect-flush race in contact-dialog tests

### DIFF
--- a/test/unit/contact-dialog.test.tsx
+++ b/test/unit/contact-dialog.test.tsx
@@ -1,4 +1,5 @@
 import { fireEvent, render, screen, waitFor } from "@testing-library/react";
+import { act } from "react";
 import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
 
 declare global {
@@ -74,6 +75,11 @@ describe("ContactDialog", () => {
   });
 
   afterEach(() => {
+    // Guard against tests that vi.useFakeTimers() and fail before reaching
+    // their own vi.useRealTimers() cleanup — a leaked fake clock stalls every
+    // subsequent test's real-time-based waitFor() polling for the full
+    // testTimeout instead of failing fast.
+    vi.useRealTimers();
     vi.restoreAllMocks();
     window.turnstile = undefined;
   });
@@ -271,7 +277,9 @@ describe("ContactDialog", () => {
       fireEvent.click(trigger);
 
       // Wait for Turnstile to initialize
-      await vi.advanceTimersByTimeAsync(300);
+      await act(async () => {
+        await vi.advanceTimersByTimeAsync(300);
+      });
 
       fillForm();
 
@@ -281,16 +289,31 @@ describe("ContactDialog", () => {
       // Submit the form
       fireEvent.submit(form as HTMLFormElement);
 
+      // Flush the mocked fetch's promise resolution so formState commits to
+      // "success" and the success->countdown effect registers its timer.
+      // This must run inside act() — React's passive-effect flush after the
+      // state update doesn't happen synchronously with a bare fake-timer
+      // advance, so the effect that schedules the countdown transition
+      // never registers without it.
+      await act(async () => {
+        await vi.advanceTimersByTimeAsync(0);
+      });
+      expect(screen.getByText(/message sent/i)).toBeInTheDocument();
+
       // Advance through the full countdown
       // Start: success -> countdown transition (1000ms) + 10 seconds of countdown
-      await vi.advanceTimersByTimeAsync(1200);
+      await act(async () => {
+        await vi.advanceTimersByTimeAsync(1200);
+      });
 
       // Verify countdown is visible
       expect(screen.getByText(/closing in/i)).toBeInTheDocument();
 
       // Advance through the countdown 1 second at a time (10 iterations + 1 for final close)
       for (let i = 0; i < 11; i++) {
-        await vi.advanceTimersByTimeAsync(1000);
+        await act(async () => {
+          await vi.advanceTimersByTimeAsync(1000);
+        });
       }
 
       // Modal should be closed (dialog should no longer be in the document)
@@ -307,7 +330,9 @@ describe("ContactDialog", () => {
       fireEvent.click(trigger);
 
       // Wait for Turnstile to initialize
-      await vi.advanceTimersByTimeAsync(300);
+      await act(async () => {
+        await vi.advanceTimersByTimeAsync(300);
+      });
 
       fillForm();
 
@@ -317,15 +342,28 @@ describe("ContactDialog", () => {
       // Submit the form
       fireEvent.submit(form as HTMLFormElement);
 
+      // Flush the mocked fetch's promise resolution so formState commits to
+      // "success" and the success->countdown effect registers its timer.
+      // Must run inside act() — see the identical comment in the
+      // "auto-closes modal" test above for why.
+      await act(async () => {
+        await vi.advanceTimersByTimeAsync(0);
+      });
+      expect(screen.getByText(/message sent/i)).toBeInTheDocument();
+
       // Advance to countdown state
-      await vi.advanceTimersByTimeAsync(1200);
+      await act(async () => {
+        await vi.advanceTimersByTimeAsync(1200);
+      });
 
       // Verify we're in countdown
       expect(screen.getByText(/closing in/i)).toBeInTheDocument();
 
       // Advance through the countdown 1 second at a time (10 iterations + 1 for final close)
       for (let i = 0; i < 11; i++) {
-        await vi.advanceTimersByTimeAsync(1000);
+        await act(async () => {
+          await vi.advanceTimersByTimeAsync(1000);
+        });
       }
 
       // Modal should be closed

--- a/test/unit/contact-dialog.test.tsx
+++ b/test/unit/contact-dialog.test.tsx
@@ -1,5 +1,10 @@
-import { fireEvent, render, screen, waitFor } from "@testing-library/react";
-import { act } from "react";
+import {
+  act,
+  fireEvent,
+  render,
+  screen,
+  waitFor,
+} from "@testing-library/react";
 import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
 
 declare global {


### PR DESCRIPTION
## Summary

Fixes 16 failing tests in `test/unit/contact-dialog.test.tsx` that were discovered while verifying an unrelated dependency upgrade (they fail identically on `main`, unrelated to that PR).

**Root cause:** `auto-closes modal when countdown reaches zero` calls `vi.useFakeTimers()` and threw (`Unable to find an element with the text: /closing in/i`) before reaching its own `vi.useRealTimers()` cleanup at the end of the test. With no `afterEach` safety net, the fake clock leaked into all 15 subsequent tests in the file. With fake timers stuck active, `@testing-library`'s `waitFor()` polling and the component's real `setInterval`-based Turnstile retry loop could never fire — each subsequent test hung for the full 10s test timeout instead of failing fast (16 failures, ~150s file runtime).

**Fixes:**
1. Added `vi.useRealTimers()` to the top-level `afterEach` — guarantees a thrown assertion in one test can never leak fake timers into the next. This alone fixed 14 of the 16 failures.
2. The two fake-timer tests themselves (`auto-closes modal when countdown reaches zero`, `reopening modal after success shows fresh form...`) still failed once isolated — `vi.advanceTimersByTimeAsync()` calls were happening outside of `act()`, so the passive effect that registers the success→countdown `setTimeout` (fired after the mocked `fetch` resolves) wasn't being flushed before the next timer advance. Wrapped all timer advances in these two tests with `act(async () => { ... })`, importing `act` from `@testing-library/react` to match this repo's existing convention (see `test/unit/locale-provider.test.tsx`, `test/unit/references-carousel.test.tsx`).

## Related Issue

N/A — found during unrelated dependency-upgrade verification, no tracked issue.

## Type of Change

- [ ] `feat` — New feature or enhancement
- [ ] `fix` — Bug fix
- [ ] `chore` — Maintenance, dependencies, or configuration
- [ ] `docs` — Documentation only
- [ ] `refactor` — Code refactoring without behavior change
- [x] `test` — Adding or updating tests

## Architecture Decision Record (ADR)

**Architecture Change?**

- [ ] Yes (add `architecture-change` label and link ADR above)
- [x] No

## Technical Governance Compliance

- [x] Complies with the supreme invariants in [Constitution](../docs/CONSTITUTION.md)
- [x] Follows [Engineering Standards](../docs/ENGINEERING_STANDARDS.md)
- [x] Follows [Architecture](../docs/ARCHITECTURE.md) guidelines
- [x] Follows [Technical Governance](https://vicenteopaso.com/technical-governance) principles
- [x] Aligns with the SDD (`/sdd.yaml`) or updates it in this PR
- [ ] Documentation updated in `docs/` (if applicable) — N/A, test-only change
- [ ] Component documentation added/updated (if applicable) — N/A
- [ ] README updated (if behavior changes) — N/A, no behavior change

## AI Governance (if applicable)

- [x] Reviewed [AI Guardrails](../docs/AI_GUARDRAILS.md) — Security constraints respected
- [x] Reviewed [Forbidden Patterns](../docs/FORBIDDEN_PATTERNS.md) — No anti-patterns introduced
- [x] Completed [Review Checklist](../docs/REVIEW_CHECKLIST.md) — All applicable items verified
- [x] Security controls maintained (Turnstile, rate limiting, input validation, HTML sanitization) — unchanged, test-only
- [x] No secrets or credentials hard-coded
- [x] Accessibility standards maintained (WCAG 2.1 AA) — unchanged, test-only
- [x] Architecture boundaries respected (no cross-layer imports)

## Quality Checks

- [x] `pnpm lint` passes
- [x] `pnpm typecheck` passes
- [x] `pnpm test` passes with adequate coverage — 372/372 passing (was 356/372)
- [ ] `pnpm test:e2e` passes (if UI/routing changes) — N/A, no UI/routing change
- [ ] Visual tests updated if UI changed (`pnpm test:visual:update`) — N/A, no UI change
- [x] Reviewed changes against [Code Review Checklist](../docs/REVIEW_CHECKLIST.md)

## CI/CD

- [x] All required checks pass (lint, typecheck, test, coverage, build, a11y, security, Lighthouse)

## AI Guardrails Compliance

- [x] Tests added/updated for code changes (unit, e2e, or visual) — this PR *is* the test fix
- [ ] Error handling verified and follows [Error Handling Guide](../docs/ERROR_HANDLING.md) — N/A, no `app/`/`lib/` changes
- [ ] Accessibility verified (keyboard navigation, ARIA, focus management) — N/A, no UI change
- [ ] SEO impact assessed and metadata updated if needed — N/A
- [ ] Security considerations reviewed (input validation, XSS prevention) — N/A, test-only

## Additional Verification

- [ ] Cross-browser testing completed (if UI changes) — N/A
- [ ] Performance impact considered (bundle size, Core Web Vitals) — N/A, test-only, no shipped code changed
- [ ] Mobile responsiveness verified (if UI changes) — N/A

## Additional Notes

Test plan:
- [x] `test/unit/contact-dialog.test.tsx` — 24/24 passing (was 8/24)
- [x] Full suite (`vitest run`) — 372/372 passing (was 356/372), runtime dropped from ~150s to ~13s
- [x] `pnpm lint` — clean (1 pre-existing unrelated warning)
- [x] `pnpm typecheck` — clean

🤖 Generated with [Claude Code](https://claude.com/claude-code)
