### PR TITLE
chore: rebalance job-matching profile toward IC/technical leadership

### DIFF
--- a/content/en/profile-preferences.json
+++ b/content/en/profile-preferences.json
@@ -6,17 +6,20 @@
   },
   "role_preferences": {
     "target_titles": [
+      "Staff Frontend Engineer",
+      "Principal Frontend Engineer",
+      "Software Architect",
+      "Frontend Architect",
+      "Senior Frontend Engineer",
+      "Tech Lead",
+      "Design System Engineer",
+      "Design System Lead",
+      "Developer Experience Engineer",
+      "Platform Engineer (Frontend-focused)",
       "Engineering Manager",
       "Web Engineering Manager",
       "Frontend Engineering Manager",
-      "Staff Frontend Engineer",
-      "Tech Lead",
-      "Principal Frontend Engineer",
-      "Platform Engineer (Frontend-focused)",
-      "Design System Manager",
-      "Design System Engineer",
-      "Design System Lead",
-      "Developer Experience Engineer"
+      "Design System Manager"
     ],
     "excluded_titles": [
       "Product Designer",
@@ -28,7 +31,7 @@
       "Intern"
     ],
     "min_seniority": "senior",
-    "management_interest": "manager_or_individual_contributor",
+    "management_interest": "Primarily individual contributor and technical leadership (Staff, Principal, Architect, Senior); open to Engineering Manager roles but deprioritizes Senior Engineering Manager, and deprioritizes Director-level roles most of all.",
     "open_to_individual_contributor": true
   },
   "domains": {
@@ -56,12 +59,15 @@
       "CI/CD",
       "Testing strategy",
       "Performance optimization",
-      "Accessibility"
+      "Accessibility",
+      "MCP Server Architecture",
+      "AI agent pipeline architecture"
     ],
     "platform_and_devex_additions": [
       "Internal platforms",
       "Tooling ownership",
-      "Documentation standards"
+      "Documentation standards",
+      "Spec-Driven Development (SDD)"
     ],
     "cloud_and_infra": [
       "Vercel",
@@ -78,9 +84,11 @@
   "experience_highlights": [
     "15+ years in software engineering with a focus on frontend architecture and design systems.",
     "Led platform and design system strategy at Carlsberg Group, building and scaling the Malty design system.",
+    "Contributed to architecture governance at Carlsberg via the Software Engineering Leadership Team and Beacon Council steering groups — defining software design standards and architecture direction alongside Architects, Principals, and Leads.",
     "Established and grew a Frontend Community of Practice across distributed teams.",
     "Experience turning under-structured environments into disciplined, high-performing engineering groups.",
-    "Hands-on with React, TypeScript, Next.js, monorepos, CI/CD, and DX tooling."
+    "Hands-on with React, TypeScript, Next.js, monorepos, CI/CD, and DX tooling.",
+    "Builds and operates autonomous AI agent pipelines in production — multi-provider LLM orchestration (Qwen, Claude, OpenAI), MCP tooling, self-healing CI — as hands-on AI-native engineering practice."
   ],
   "location_preferences": {
     "primary_locations": [
@@ -152,12 +160,14 @@
       "Modern engineering practices",
       "Healthy remote culture",
       "Investment in DX and design systems",
-      "Clear product strategy"
+      "Clear product strategy",
+      "Frontend-forward scope (React/TypeScript) or staff/principal/architect-level technical leadership, even in backend-adjacent orgs"
     ],
     "red_flags": [
       "No clear ownership of frontend architecture or DX",
       "Purely maintenance roles with little strategic impact",
-      "Late-stage waterfall processes marketed as agile"
+      "Late-stage waterfall processes marketed as agile",
+      "Backend-only roles centered on Java, Spring Boot, or pure DevOps/SRE/infrastructure work with no frontend or technical-leadership component"
     ]
   },
   "hard_constraints": {

--- a/content/es/profile-preferences.json
+++ b/content/es/profile-preferences.json
@@ -6,17 +6,20 @@
   },
   "role_preferences": {
     "target_titles": [
+      "Staff Frontend Engineer",
+      "Principal Frontend Engineer",
+      "Software Architect",
+      "Frontend Architect",
+      "Senior Frontend Engineer",
+      "Tech Lead",
+      "Design System Engineer",
+      "Design System Lead",
+      "Developer Experience Engineer",
+      "Platform Engineer (Frontend-focused)",
       "Engineering Manager",
       "Web Engineering Manager",
       "Frontend Engineering Manager",
-      "Staff Frontend Engineer",
-      "Tech Lead",
-      "Principal Frontend Engineer",
-      "Platform Engineer (Frontend-focused)",
-      "Design System Manager",
-      "Design System Engineer",
-      "Design System Lead",
-      "Developer Experience Engineer"
+      "Design System Manager"
     ],
     "excluded_titles": [
       "Product Designer",
@@ -28,7 +31,7 @@
       "Intern"
     ],
     "min_seniority": "senior",
-    "management_interest": "manager_or_individual_contributor",
+    "management_interest": "Primarily individual contributor and technical leadership (Staff, Principal, Architect, Senior); open to Engineering Manager roles but deprioritizes Senior Engineering Manager, and deprioritizes Director-level roles most of all.",
     "open_to_individual_contributor": true
   },
   "domains": {
@@ -56,12 +59,15 @@
       "CI/CD",
       "Testing strategy",
       "Performance optimization",
-      "Accessibility"
+      "Accessibility",
+      "MCP Server Architecture",
+      "AI agent pipeline architecture"
     ],
     "platform_and_devex_additions": [
       "Internal platforms",
       "Tooling ownership",
-      "Documentation standards"
+      "Documentation standards",
+      "Spec-Driven Development (SDD)"
     ],
     "cloud_and_infra": [
       "Vercel",
@@ -78,9 +84,11 @@
   "experience_highlights": [
     "15+ años en ingeniería de software con foco en arquitectura frontend y design systems.",
     "Lideró la estrategia de plataforma y design systems en Carlsberg Group, construyendo y escalando el design system Malty.",
+    "Contribuyó a la gobernanza de arquitectura en Carlsberg a través de los comités directivos Software Engineering Leadership Team y Beacon Council — definiendo estándares de diseño de software y dirección de arquitectura junto a Architects, Principals y Leads.",
     "Creó y amplió una Frontend Community of Practice entre equipos distribuidos.",
     "Experiencia convirtiendo entornos poco estructurados en equipos de ingeniería disciplinados y de alto rendimiento.",
-    "Hands-on con React, TypeScript, Next.js, monorepos, CI/CD y tooling de DX."
+    "Hands-on con React, TypeScript, Next.js, monorepos, CI/CD y tooling de DX.",
+    "Construye y opera pipelines de agentes de IA autónomos en producción — orquestación multi-proveedor de LLMs (Qwen, Claude, OpenAI), tooling MCP, CI auto-reparable — como práctica hands-on de ingeniería AI-native."
   ],
   "location_preferences": {
     "primary_locations": [
@@ -152,12 +160,14 @@
       "Prácticas modernas de ingeniería",
       "Cultura remota saludable",
       "Inversión en DX y design systems",
-      "Estrategia de producto clara"
+      "Estrategia de producto clara",
+      "Alcance frontend-forward (React/TypeScript) o liderazgo técnico a nivel staff/principal/architect, incluso en organizaciones backend-adjacent"
     ],
     "red_flags": [
       "Sin ownership claro de arquitectura frontend o DX",
       "Roles puramente de mantenimiento con poco impacto estratégico",
-      "Procesos waterfall tardíos vendidos como agile"
+      "Procesos waterfall tardíos vendidos como agile",
+      "Roles puramente backend centrados en Java, Spring Boot, o trabajo puro de DevOps/SRE/infraestructura sin componente frontend o de liderazgo técnico"
     ]
   },
   "hard_constraints": {


### PR DESCRIPTION
## Summary

Rebalances `content/{en,es}/profile-preferences.json` — the data source for job-search's LLM matching prompt (via `lib/profile.ts` → `app/api/profile/[lang]/route.ts`) — away from people-management framing and toward Staff/Principal/Architect IC roles, and softly deprioritizes backend-only roles without hard-excluding anything.

**Title/stack rebalancing:**
- Reordered `target_titles` so IC/technical-leadership titles lead and manager titles trail; added Software Architect, Frontend Architect, Senior Frontend Engineer.
- Replaced the `management_interest` enum (`manager_or_individual_contributor`) with a graduated-preference sentence injected verbatim into the matching prompt.
- Added `must_haves`/`red_flags` entries nudging toward frontend-forward or staff/principal/architect scope, away from backend-only Java/Spring/DevOps-SRE roles.

**Reconciling with recent CV/site content:**
- Added an `experience_highlights` bullet for the Carlsberg governance steering groups (Software Engineering Leadership Team, Beacon Council — commit 8854aab) — architecture-governance experience distinct from people management, supporting the Staff/Principal/Architect positioning.
- Added `architecture_additions`/`platform_and_devex_additions` entries for "MCP Server Architecture" and "Spec-Driven Development (SDD)". These already exist as `cv.json` keywords (commit c683fb4) but `lib/profile.ts`'s `buildArchitectureSkills`/`buildPlatformAndDevexSkills` only auto-surface a fixed filter list, so they were silently dropped from the derived profile until now.
- Added an `experience_highlights` bullet reflecting the AI agent pipeline work (Dev Team on Qwen/Modal, multi-provider LLM orchestration) now featured in the homepage's "WHAT I BUILD" section (commits c683fb4, 665b29f).

Mirrored to `content/es/` for site consistency (role/title fields and technical-term additions kept in English, matching that file's existing convention; prose fields translated) — though job-search only reads the `/en/` endpoint by default, so this is secondary.

`hard_constraints`, `excluded_titles`, and `compensation_and_level` are untouched — none of this is a hard exclusion.

## Related Issue

N/A

## Type of Change

- [x] `chore` — Maintenance, dependencies, or configuration

## Architecture Decision Record (ADR)

**Architecture Change?**

- [ ] Yes (add `architecture-change` label and link ADR above)
- [x] No — content/data change only, no code or architecture touched

## Technical Governance Compliance

- [x] Complies with the supreme invariants in [Constitution](../docs/CONSTITUTION.md)
- [x] Follows [Engineering Standards](../docs/ENGINEERING_STANDARDS.md)
- [x] Follows [Architecture](../docs/ARCHITECTURE.md) guidelines
- [ ] Follows [Technical Governance](https://vicenteopaso.com/technical-governance) principles
- [x] Aligns with the SDD (`/sdd.yaml`) or updates it in this PR — no SDD changes needed
- [ ] Documentation updated in `docs/` (if applicable) — not applicable
- [ ] Component documentation added/updated (if applicable) — not applicable
- [ ] README updated (if behavior changes) — not applicable

## AI Governance (if applicable)

- [x] Reviewed [AI Guardrails](../docs/AI_GUARDRAILS.md) — Security constraints respected
- [x] Reviewed [Forbidden Patterns](../docs/FORBIDDEN_PATTERNS.md) — No anti-patterns introduced
- [x] Completed [Review Checklist](../docs/REVIEW_CHECKLIST.md) — All applicable items verified
- [x] Security controls maintained (Turnstile, rate limiting, input validation, HTML sanitization) — untouched, not in scope
- [x] No secrets or credentials hard-coded
- [x] Accessibility standards maintained (WCAG 2.1 AA) — untouched, not in scope
- [x] Architecture boundaries respected (no cross-layer imports)

## Quality Checks

- [x] `pnpm lint` — not applicable (JSON content only, no source touched)
- [x] `pnpm typecheck` passes (verified via `tsc --noEmit`)
- [x] `pnpm test` passes with adequate coverage (verified `lib/profile.ts` + `app/api/profile` suite: 9 passed)
- [ ] `pnpm test:e2e` passes (if UI/routing changes) — no UI/routing changes
- [ ] Visual tests updated if UI changed (`pnpm test:visual:update`) — no UI changes
- [x] Reviewed changes against [Code Review Checklist](../docs/REVIEW_CHECKLIST.md)

## CI/CD

- [x] All required checks pass (lint, typecheck, test, coverage, build, a11y, security, Lighthouse)

## AI Guardrails Compliance

- [ ] Tests added/updated for code changes (unit, e2e, or visual) — no code changed, only JSON content data
- [x] Error handling verified and follows [Error Handling Guide](../docs/ERROR_HANDLING.md) — untouched
- [x] Accessibility verified (keyboard navigation, ARIA, focus management) — untouched
- [ ] SEO impact assessed and metadata updated if needed — not applicable
- [x] Security considerations reviewed (input validation, XSS prevention) — untouched

## Additional Verification

- [ ] Cross-browser testing completed (if UI changes) — no UI changes
- [ ] Performance impact considered (bundle size, Core Web Vitals) — not applicable
- [ ] Mobile responsiveness verified (if UI changes) — no UI changes

## Additional Notes

- Content-only change to `content/{en,es}/profile-preferences.json`; no `app/` or `lib/` code was modified.
- Verified via `getCanonicalProfile()` (through `tsx`) that both locale files still parse against the `lib/profile.ts` zod schema, and that the new architecture/platform_and_devex additions surface correctly in the derived profile.
- Known pre-existing gap outside this PR's scope: `content/es/cv.json`'s "Experiencia de Desarrollador" skill is missing the "Spec-Driven Development (SDD)" / "MCP Server Architecture" keywords that `content/en/cv.json` has (from commit c683fb4) — doesn't affect job-search since it only reads `/en/`, but worth a follow-up.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
