### PR TITLE
feat: add unlisted /lost-luggage page with Telegram/Formspree alerts

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -8,6 +8,12 @@ TURNSTILE_SECRET_KEY=
 # Formspree form ID used to build the contact endpoint
 NEXT_PUBLIC_FORMSPREE_KEY=
 
+# --- Lost luggage page notifications (/lost-luggage) ---
+# Telegram bot token, from @BotFather
+TELEGRAM_BOT_TOKEN=
+# Telegram chat ID to send the alert to
+TELEGRAM_CHAT_ID=
+
 # --- Sentry error tracking ---
 # Secret DSN for Sentry (server + edge SDK)
 # Obtain from: Sentry Project Settings > Client Keys (DSN)

--- a/app/[lang]/lost-luggage/page.tsx
+++ b/app/[lang]/lost-luggage/page.tsx
@@ -1,0 +1,68 @@
+import type { Metadata } from "next";
+import ReactMarkdown from "react-markdown";
+
+import { ContentPageShell } from "@/app/components/ContentPageShell";
+import { LostLuggageNotifier } from "@/app/components/LostLuggageNotifier";
+import { loadContentPage } from "@/lib/content";
+import { getLocaleFromParams } from "@/lib/i18n";
+
+import { markdownComponents } from "../../../lib/markdown-components";
+import { baseMetadata } from "../../../lib/seo";
+
+// Unlisted page: reachable only via the QR code on the luggage tag, not
+// linked from any nav or footer, and excluded from the sitemap (see
+// next-sitemap.config.js).
+export const dynamic = "force-static";
+
+export async function generateStaticParams() {
+  return [{ lang: "en" }, { lang: "es" }];
+}
+
+export async function generateMetadata(): Promise<Metadata> {
+  return baseMetadata({
+    title: "Lost Luggage",
+    description: "Contact info for whoever found this bag.",
+    robots: {
+      index: false,
+      follow: false,
+    },
+    openGraph: {
+      title: "Lost Luggage",
+      description: "Contact info for whoever found this bag.",
+    },
+  });
+}
+
+interface PageProps {
+  params: Promise<{ lang: string }>;
+}
+
+export default async function LostLuggagePage({ params }: PageProps) {
+  const { lang } = await params;
+  const locale = getLocaleFromParams({ lang });
+
+  const { data, content } = loadContentPage(locale, "lost-luggage");
+
+  return (
+    <ContentPageShell>
+      <LostLuggageNotifier locale={locale} />
+      <article className="section-card space-y-6">
+        <header>
+          <h1 className="text-2xl font-bold text-[color:var(--text-primary)] sm:text-3xl">
+            {data.title}
+          </h1>
+          {data.description && (
+            <p className="mt-2 text-base text-[color:var(--text-muted)]">
+              {data.description}
+            </p>
+          )}
+        </header>
+        <div className="prose prose-sm max-w-none sm:prose-base">
+          <ReactMarkdown components={markdownComponents}>
+            {content}
+          </ReactMarkdown>
+        </div>
+      </article>
+    </ContentPageShell>
+  );
+}

--- a/app/[lang]/lost-luggage/page.tsx
+++ b/app/[lang]/lost-luggage/page.tsx
@@ -1,5 +1,5 @@
 import type { Metadata } from "next";
-import ReactMarkdown from "react-markdown";
+import ReactMarkdown, { defaultUrlTransform } from "react-markdown";
 
 import { ContentPageShell } from "@/app/components/ContentPageShell";
 import { LostLuggageNotifier } from "@/app/components/LostLuggageNotifier";
@@ -37,6 +37,13 @@ interface PageProps {
   params: Promise<{ lang: string }>;
 }
 
+// react-markdown's default URL sanitizer only allows http(s)/mailto/irc(s)/xmpp
+// and strips everything else (including tel:), so the phone contact link
+// needs an explicit allowance here.
+function urlTransform(url: string): string {
+  return url.startsWith("tel:") ? url : defaultUrlTransform(url);
+}
+
 export default async function LostLuggagePage({ params }: PageProps) {
   const { lang } = await params;
   const locale = getLocaleFromParams({ lang });
@@ -58,7 +65,7 @@ export default async function LostLuggagePage({ params }: PageProps) {
           )}
         </header>
         <div className="prose prose-sm max-w-none sm:prose-base">
-          <ReactMarkdown components={markdownComponents}>
+          <ReactMarkdown components={markdownComponents} urlTransform={urlTransform}>
             {content}
           </ReactMarkdown>
         </div>

--- a/app/api/lost-luggage-notify/route.ts
+++ b/app/api/lost-luggage-notify/route.ts
@@ -102,6 +102,16 @@ export async function POST(request: NextRequest) {
     return NextResponse.json({ ok: true });
   }
 
+  let parsed: z.infer<typeof notifySchema>;
+  try {
+    const json = await request.json();
+    parsed = notifySchema.parse(json);
+  } catch {
+    // Malformed payloads are rejected before touching the rate limiter, so
+    // they can't be used to burn a legitimate visitor's quota.
+    return NextResponse.json({ ok: true });
+  }
+
   const ipFromHeader =
     request.headers.get("x-forwarded-for") ||
     request.headers.get("cf-connecting-ip") ||
@@ -118,14 +128,6 @@ export async function POST(request: NextRequest) {
         "Retry-After": String(retryAfterSeconds),
       },
     });
-  }
-
-  let parsed: z.infer<typeof notifySchema>;
-  try {
-    const json = await request.json();
-    parsed = notifySchema.parse(json);
-  } catch {
-    return NextResponse.json({ ok: true });
   }
 
   const message = buildMessage({

--- a/app/api/lost-luggage-notify/route.ts
+++ b/app/api/lost-luggage-notify/route.ts
@@ -19,6 +19,15 @@ const TELEGRAM_BOT_TOKEN = process.env.TELEGRAM_BOT_TOKEN;
 const TELEGRAM_CHAT_ID = process.env.TELEGRAM_CHAT_ID;
 const FORMSPREE_KEY = process.env.NEXT_PUBLIC_FORMSPREE_KEY;
 
+const MAX_FIELD_LENGTH = 200;
+
+// Collapses newlines and bounds length so request-controlled fields (referrer,
+// user-agent, geo headers) can't inject extra lines into the Telegram/Formspree
+// message or blow past their size limits.
+function sanitizeField(value: string): string {
+  return value.replace(/[\r\n]+/g, " ").slice(0, MAX_FIELD_LENGTH);
+}
+
 function buildMessage(params: {
   locale: string;
   referrer: string | undefined;
@@ -32,9 +41,9 @@ function buildMessage(params: {
     "Someone opened the lost-luggage page.",
     `Time: ${timestamp}`,
     `Locale: ${locale}`,
-    `Location: ${city}, ${country}`,
-    `Referrer: ${referrer || "(none)"}`,
-    `User agent: ${userAgent}`,
+    `Location: ${sanitizeField(city)}, ${sanitizeField(country)}`,
+    `Referrer: ${referrer ? sanitizeField(referrer) : "(none)"}`,
+    `User agent: ${sanitizeField(userAgent)}`,
   ].join("\n");
 }
 
@@ -83,6 +92,16 @@ async function notifyFormspree(message: string): Promise<void> {
 }
 
 export async function POST(request: NextRequest) {
+  // Best-effort CSRF/spam guard: browsers send Origin on POST requests, so
+  // reject cross-site callers when it's present but doesn't match the origin
+  // the request actually arrived at (works across dev/preview/prod without
+  // hardcoding a domain). Requests without an Origin header (e.g.
+  // server-to-server) are unaffected.
+  const origin = request.headers.get("origin");
+  if (origin && origin !== request.nextUrl.origin) {
+    return NextResponse.json({ ok: true });
+  }
+
   const ipFromHeader =
     request.headers.get("x-forwarded-for") ||
     request.headers.get("cf-connecting-ip") ||

--- a/app/api/lost-luggage-notify/route.ts
+++ b/app/api/lost-luggage-notify/route.ts
@@ -3,6 +3,7 @@ import { NextResponse } from "next/server";
 import { z } from "zod";
 
 import { logWarning } from "@/lib/error-logging";
+import { locales } from "@/lib/i18n";
 import { checkRateLimitForKey } from "@/lib/rate-limit";
 
 // Fires a best-effort notification (Telegram + Formspree) whenever the
@@ -10,8 +11,8 @@ import { checkRateLimitForKey } from "@/lib/rate-limit";
 // directly. Failures here never surface to the visitor.
 
 const notifySchema = z.object({
-  locale: z.string().max(10),
-  referrer: z.string().max(500).optional(),
+  locale: z.enum(locales),
+  referrer: z.string().url().max(500).optional(),
 });
 
 const TELEGRAM_BOT_TOKEN = process.env.TELEGRAM_BOT_TOKEN;
@@ -90,9 +91,14 @@ export async function POST(request: NextRequest) {
 
   const rateLimitResult = checkRateLimitForKey(`lost-luggage:${clientIp}`);
   if (!rateLimitResult.allowed) {
-    // Silently accept — a rate-limited notify attempt shouldn't error out
-    // for the visitor, it just won't page Vicente again this window.
-    return NextResponse.json({ ok: true });
+    const { retryAfterSeconds } = rateLimitResult;
+    return new NextResponse(JSON.stringify({ error: "Too many requests." }), {
+      status: 429,
+      headers: {
+        "Content-Type": "application/json",
+        "Retry-After": String(retryAfterSeconds),
+      },
+    });
   }
 
   let parsed: z.infer<typeof notifySchema>;

--- a/app/api/lost-luggage-notify/route.ts
+++ b/app/api/lost-luggage-notify/route.ts
@@ -1,0 +1,130 @@
+import type { NextRequest } from "next/server";
+import { NextResponse } from "next/server";
+import { z } from "zod";
+
+import { logWarning } from "@/lib/error-logging";
+import { checkRateLimitForKey } from "@/lib/rate-limit";
+
+// Fires a best-effort notification (Telegram + Formspree) whenever the
+// unlisted /lost-luggage page is viewed, so a real visit reaches Vicente
+// directly. Failures here never surface to the visitor.
+
+const notifySchema = z.object({
+  locale: z.string().max(10),
+  referrer: z.string().max(500).optional(),
+});
+
+const TELEGRAM_BOT_TOKEN = process.env.TELEGRAM_BOT_TOKEN;
+const TELEGRAM_CHAT_ID = process.env.TELEGRAM_CHAT_ID;
+const FORMSPREE_KEY = process.env.NEXT_PUBLIC_FORMSPREE_KEY;
+
+function buildMessage(params: {
+  locale: string;
+  referrer: string | undefined;
+  userAgent: string;
+  country: string;
+  city: string;
+  timestamp: string;
+}): string {
+  const { locale, referrer, userAgent, country, city, timestamp } = params;
+  return [
+    "Someone opened the lost-luggage page.",
+    `Time: ${timestamp}`,
+    `Locale: ${locale}`,
+    `Location: ${city}, ${country}`,
+    `Referrer: ${referrer || "(none)"}`,
+    `User agent: ${userAgent}`,
+  ].join("\n");
+}
+
+async function notifyTelegram(message: string): Promise<void> {
+  if (!TELEGRAM_BOT_TOKEN || !TELEGRAM_CHAT_ID) {
+    return;
+  }
+
+  const response = await fetch(
+    `https://api.telegram.org/bot${TELEGRAM_BOT_TOKEN}/sendMessage`,
+    {
+      method: "POST",
+      headers: { "Content-Type": "application/json" },
+      body: JSON.stringify({
+        chat_id: TELEGRAM_CHAT_ID,
+        text: message,
+      }),
+    },
+  );
+
+  if (!response.ok) {
+    throw new Error(`Telegram notify failed with status ${response.status}`);
+  }
+}
+
+async function notifyFormspree(message: string): Promise<void> {
+  if (!FORMSPREE_KEY) {
+    return;
+  }
+
+  const response = await fetch(`https://formspree.io/f/${FORMSPREE_KEY}`, {
+    method: "POST",
+    headers: {
+      "Content-Type": "application/json",
+      Accept: "application/json",
+    },
+    body: JSON.stringify({
+      subject: "Lost luggage page viewed",
+      message,
+    }),
+  });
+
+  if (!response.ok) {
+    throw new Error(`Formspree notify failed with status ${response.status}`);
+  }
+}
+
+export async function POST(request: NextRequest) {
+  const ipFromHeader =
+    request.headers.get("x-forwarded-for") ||
+    request.headers.get("cf-connecting-ip") ||
+    undefined;
+  const clientIp = ipFromHeader?.split(",")[0].trim() ?? "unknown";
+
+  const rateLimitResult = checkRateLimitForKey(`lost-luggage:${clientIp}`);
+  if (!rateLimitResult.allowed) {
+    // Silently accept — a rate-limited notify attempt shouldn't error out
+    // for the visitor, it just won't page Vicente again this window.
+    return NextResponse.json({ ok: true });
+  }
+
+  let parsed: z.infer<typeof notifySchema>;
+  try {
+    const json = await request.json();
+    parsed = notifySchema.parse(json);
+  } catch {
+    return NextResponse.json({ ok: true });
+  }
+
+  const message = buildMessage({
+    locale: parsed.locale,
+    referrer: parsed.referrer,
+    userAgent: request.headers.get("user-agent") || "(unknown)",
+    country: request.headers.get("x-vercel-ip-country") || "(unknown)",
+    city: request.headers.get("x-vercel-ip-city") || "(unknown)",
+    timestamp: new Date().toISOString(),
+  });
+
+  const results = await Promise.allSettled([
+    notifyTelegram(message),
+    notifyFormspree(message),
+  ]);
+
+  for (const result of results) {
+    if (result.status === "rejected") {
+      logWarning("Lost luggage notify failed", {
+        component: "lost-luggage-notify",
+        metadata: { reason: String(result.reason) },
+      });
+    }
+  }
+
+  return NextResponse.json({ ok: true });
+}

--- a/app/components/LostLuggageNotifier.tsx
+++ b/app/components/LostLuggageNotifier.tsx
@@ -2,10 +2,12 @@
 
 import { useEffect } from "react";
 
+import type { Locale } from "@/lib/i18n";
+
 // Fires a best-effort beacon to /api/lost-luggage-notify on page view so a
 // real visit pages Vicente. Keeps the page itself statically generated —
 // only this client component runs per-visit.
-export function LostLuggageNotifier({ locale }: { locale: string }) {
+export function LostLuggageNotifier({ locale }: { locale: Locale }) {
   useEffect(() => {
     fetch("/api/lost-luggage-notify", {
       method: "POST",

--- a/app/components/LostLuggageNotifier.tsx
+++ b/app/components/LostLuggageNotifier.tsx
@@ -4,18 +4,26 @@ import { useEffect } from "react";
 
 import type { Locale } from "@/lib/i18n";
 
+// Matches the server's `referrer` max length (app/api/lost-luggage-notify/
+// route.ts). Omitting an oversized referrer instead of truncating it avoids
+// sending a malformed URL that would fail server-side validation and drop
+// the whole notification.
+const MAX_REFERRER_LENGTH = 500;
+
 // Fires a best-effort beacon to /api/lost-luggage-notify on page view so a
 // real visit pages Vicente. Keeps the page itself statically generated —
 // only this client component runs per-visit.
 export function LostLuggageNotifier({ locale }: { locale: Locale }) {
   useEffect(() => {
+    const referrer =
+      document.referrer && document.referrer.length <= MAX_REFERRER_LENGTH
+        ? document.referrer
+        : undefined;
+
     fetch("/api/lost-luggage-notify", {
       method: "POST",
       headers: { "Content-Type": "application/json" },
-      body: JSON.stringify({
-        locale,
-        referrer: document.referrer || undefined,
-      }),
+      body: JSON.stringify({ locale, referrer }),
       keepalive: true,
     }).catch(() => {
       // Best-effort only — a failed notify should never affect the visitor.

--- a/app/components/LostLuggageNotifier.tsx
+++ b/app/components/LostLuggageNotifier.tsx
@@ -1,0 +1,24 @@
+"use client";
+
+import { useEffect } from "react";
+
+// Fires a best-effort beacon to /api/lost-luggage-notify on page view so a
+// real visit pages Vicente. Keeps the page itself statically generated —
+// only this client component runs per-visit.
+export function LostLuggageNotifier({ locale }: { locale: string }) {
+  useEffect(() => {
+    fetch("/api/lost-luggage-notify", {
+      method: "POST",
+      headers: { "Content-Type": "application/json" },
+      body: JSON.stringify({
+        locale,
+        referrer: document.referrer || undefined,
+      }),
+      keepalive: true,
+    }).catch(() => {
+      // Best-effort only — a failed notify should never affect the visitor.
+    });
+  }, [locale]);
+
+  return null;
+}

--- a/app/lost-luggage/page.tsx
+++ b/app/lost-luggage/page.tsx
@@ -1,0 +1,35 @@
+import type { Route } from "next";
+import { headers } from "next/headers";
+import { redirect } from "next/navigation";
+
+import { defaultLocale, isValidLocale, type Locale } from "@/lib/i18n";
+
+// No-locale entry point for the QR code on the luggage tag. Detects the
+// visitor's preferred locale from Accept-Language and redirects into the
+// localized page; falls back to English when nothing matches.
+export const dynamic = "force-dynamic";
+
+function pickLocale(acceptLanguage: string | null): Locale {
+  if (!acceptLanguage) {
+    return defaultLocale;
+  }
+
+  const preferred = acceptLanguage
+    .split(",")
+    .map((part) => part.split(";")[0].trim().toLowerCase().slice(0, 2));
+
+  for (const lang of preferred) {
+    if (isValidLocale(lang)) {
+      return lang;
+    }
+  }
+
+  return defaultLocale;
+}
+
+export default async function LostLuggageRedirectPage() {
+  const headerList = await headers();
+  const locale = pickLocale(headerList.get("accept-language"));
+
+  redirect(`/${locale}/lost-luggage` as Route);
+}

--- a/content/en/lost-luggage.md
+++ b/content/en/lost-luggage.md
@@ -1,0 +1,18 @@
+---
+name: Lost Luggage
+title: You found my luggage!
+slug: lost-luggage
+description: Contact info for whoever found this bag — thank you for scanning the QR code.
+---
+
+Thank you for taking the time to scan this code. If you're reading this, you've found a bag belonging to:
+
+## Vicente Opaso
+
+Please reach out using whichever method is easiest for you:
+
+- **Email:** [vicente@opa.so](mailto:vicente@opa.so)
+- **Phone:** [+34 684 00 52 62](tel:+34684005262)
+- **WhatsApp:** [Message on WhatsApp](https://wa.me/34684005262)
+
+I really appreciate your help getting this back to me — thank you!

--- a/content/es/lost-luggage.md
+++ b/content/es/lost-luggage.md
@@ -1,0 +1,18 @@
+---
+name: Equipaje Perdido
+title: ¡Encontraste mi equipaje!
+slug: lost-luggage
+description: Información de contacto para quien encontró esta maleta — gracias por escanear el código QR.
+---
+
+Gracias por tomarte el tiempo de escanear este código. Si estás leyendo esto, encontraste una maleta que pertenece a:
+
+## Vicente Opaso
+
+Por favor contáctame usando el método que te resulte más fácil:
+
+- **Correo electrónico:** [vicente@opa.so](mailto:vicente@opa.so)
+- **Teléfono:** [+34 684 00 52 62](tel:+34684005262)
+- **WhatsApp:** [Escríbeme por WhatsApp](https://wa.me/34684005262)
+
+Te agradezco mucho tu ayuda para recuperarla — ¡muchas gracias!

--- a/eslint.config.mjs
+++ b/eslint.config.mjs
@@ -241,6 +241,7 @@ export default [
       "app/components/CvRefCard.tsx",
       "app/components/AnalyticsWrapper.tsx",
       "app/components/LocaleProvider.tsx",
+      "app/components/LostLuggageNotifier.tsx",
       "app/global-error.tsx",
       "app/components/ErrorBoundary.tsx",
     ],

--- a/next-sitemap.config.js
+++ b/next-sitemap.config.js
@@ -31,5 +31,9 @@ module.exports = {
     "/*/icon",
     "/apple-icon",
     "/*/apple-icon",
+    // Lost-luggage QR code page: publicly reachable by direct link only,
+    // intentionally not advertised via nav/footer or search indexing.
+    "/lost-luggage",
+    "/*/lost-luggage",
   ],
 };

--- a/test/unit/lost-luggage-notifier.test.tsx
+++ b/test/unit/lost-luggage-notifier.test.tsx
@@ -47,6 +47,26 @@ describe("LostLuggageNotifier", () => {
     expect(body.referrer).toBeUndefined();
   });
 
+  it("omits an oversized referrer instead of sending a truncated URL", async () => {
+    const fetchMock = vi.fn().mockResolvedValue({ ok: true } as Response);
+    global.fetch = fetchMock as unknown as typeof fetch;
+    const oversizedReferrer = `https://example.com/${"x".repeat(500)}`;
+    expect(oversizedReferrer.length).toBeGreaterThan(500);
+    Object.defineProperty(document, "referrer", {
+      value: oversizedReferrer,
+      configurable: true,
+    });
+
+    render(<LostLuggageNotifier locale="en" />);
+
+    await vi.waitFor(() => expect(fetchMock).toHaveBeenCalledTimes(1));
+
+    const [, init] = fetchMock.mock.calls[0];
+    const body = JSON.parse((init as { body: string }).body);
+    expect(body.locale).toBe("en");
+    expect(body.referrer).toBeUndefined();
+  });
+
   it("swallows a failed notify without throwing", async () => {
     const fetchMock = vi.fn().mockRejectedValue(new Error("network down"));
     global.fetch = fetchMock as unknown as typeof fetch;

--- a/test/unit/lost-luggage-notifier.test.tsx
+++ b/test/unit/lost-luggage-notifier.test.tsx
@@ -1,0 +1,65 @@
+import { render } from "@testing-library/react";
+import { afterEach, describe, expect, it, vi } from "vitest";
+
+import { LostLuggageNotifier } from "../../app/components/LostLuggageNotifier";
+
+afterEach(() => {
+  vi.restoreAllMocks();
+});
+
+describe("LostLuggageNotifier", () => {
+  it("fires a beacon to the notify endpoint on mount with locale and referrer", async () => {
+    const fetchMock = vi.fn().mockResolvedValue({ ok: true } as Response);
+    global.fetch = fetchMock as unknown as typeof fetch;
+    Object.defineProperty(document, "referrer", {
+      value: "https://example.com/qr",
+      configurable: true,
+    });
+
+    render(<LostLuggageNotifier locale="es" />);
+
+    await vi.waitFor(() => expect(fetchMock).toHaveBeenCalledTimes(1));
+
+    const [url, init] = fetchMock.mock.calls[0];
+    expect(url).toBe("/api/lost-luggage-notify");
+    expect(init).toMatchObject({ method: "POST", keepalive: true });
+    const body = JSON.parse((init as { body: string }).body);
+    expect(body).toEqual({
+      locale: "es",
+      referrer: "https://example.com/qr",
+    });
+  });
+
+  it("omits referrer when none is present", async () => {
+    const fetchMock = vi.fn().mockResolvedValue({ ok: true } as Response);
+    global.fetch = fetchMock as unknown as typeof fetch;
+    Object.defineProperty(document, "referrer", {
+      value: "",
+      configurable: true,
+    });
+
+    render(<LostLuggageNotifier locale="en" />);
+
+    await vi.waitFor(() => expect(fetchMock).toHaveBeenCalledTimes(1));
+
+    const [, init] = fetchMock.mock.calls[0];
+    const body = JSON.parse((init as { body: string }).body);
+    expect(body.referrer).toBeUndefined();
+  });
+
+  it("swallows a failed notify without throwing", async () => {
+    const fetchMock = vi.fn().mockRejectedValue(new Error("network down"));
+    global.fetch = fetchMock as unknown as typeof fetch;
+
+    expect(() => render(<LostLuggageNotifier locale="en" />)).not.toThrow();
+    await vi.waitFor(() => expect(fetchMock).toHaveBeenCalledTimes(1));
+  });
+
+  it("renders nothing", () => {
+    const fetchMock = vi.fn().mockResolvedValue({ ok: true } as Response);
+    global.fetch = fetchMock as unknown as typeof fetch;
+
+    const { container } = render(<LostLuggageNotifier locale="en" />);
+    expect(container).toBeEmptyDOMElement();
+  });
+});

--- a/test/unit/lost-luggage-notify-route.test.ts
+++ b/test/unit/lost-luggage-notify-route.test.ts
@@ -1,9 +1,12 @@
 import type { NextRequest } from "next/server";
 import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
 
+const TEST_ORIGIN = "http://localhost:3000";
+
 interface MockRequestInit {
   json: () => Promise<unknown>;
   headers?: Headers;
+  nextUrl: { origin: string };
 }
 
 async function createPostHandler() {
@@ -18,9 +21,14 @@ function createRequest(body: unknown, headers?: Record<string, string>) {
   const init: MockRequestInit = {
     json: async () => body,
     headers: h,
+    nextUrl: { origin: TEST_ORIGIN },
   };
 
   return init as unknown as NextRequest;
+}
+
+function isRequestToHost(call: unknown[], hostname: string): boolean {
+  return new URL(String(call[0])).hostname === hostname;
 }
 
 const basePayload = {
@@ -63,7 +71,7 @@ describe("app/api/lost-luggage-notify/route POST", () => {
     expect(fetchMock).toHaveBeenCalledTimes(2);
 
     const telegramCall = fetchMock.mock.calls.find((call) =>
-      String(call[0]).includes("api.telegram.org"),
+      isRequestToHost(call, "api.telegram.org"),
     );
     expect(telegramCall).toBeDefined();
     expect(String(telegramCall?.[0])).toContain("bot-token");
@@ -77,10 +85,45 @@ describe("app/api/lost-luggage-notify/route POST", () => {
     expect(telegramBody.text).toContain("test-agent");
 
     const formspreeCall = fetchMock.mock.calls.find((call) =>
-      String(call[0]).includes("formspree.io"),
+      isRequestToHost(call, "formspree.io"),
     );
     expect(formspreeCall).toBeDefined();
     expect(String(formspreeCall?.[0])).toContain("forms-key");
+  });
+
+  it("truncates an oversized request-controlled field before sending", async () => {
+    const fetchMock = vi.fn().mockResolvedValue({ ok: true } as Response);
+    global.fetch = fetchMock as unknown as typeof fetch;
+
+    const POST = await createPostHandler();
+    // The Headers API itself rejects raw CR/LF in header values (per the
+    // Fetch spec), so header-sourced fields can't carry literal newlines —
+    // the exploitable part of an oversized/attacker-controlled header is
+    // unbounded length, which this test covers.
+    const oversizedUserAgent = `evil-agent-${"x".repeat(400)}`;
+    const req = createRequest(basePayload, {
+      "x-forwarded-for": "203.0.113.12",
+      "user-agent": oversizedUserAgent,
+    });
+
+    const res = await POST(req);
+    expect(res.status).toBe(200);
+
+    const telegramCall = fetchMock.mock.calls.find((call) =>
+      isRequestToHost(call, "api.telegram.org"),
+    );
+    const telegramBody = JSON.parse(
+      (telegramCall?.[1] as { body: string }).body,
+    );
+
+    const userAgentLine = telegramBody.text
+      .split("\n")
+      .find((line: string) => line.startsWith("User agent:"));
+    expect(userAgentLine).toBeDefined();
+    expect(userAgentLine.length).toBeLessThanOrEqual(
+      "User agent: ".length + 200,
+    );
+    expect(oversizedUserAgent.length).toBeGreaterThan(200);
   });
 
   it("skips Telegram when credentials are not configured", async () => {
@@ -99,7 +142,9 @@ describe("app/api/lost-luggage-notify/route POST", () => {
     expect(res.status).toBe(200);
     // Only Formspree should have been called.
     expect(fetchMock).toHaveBeenCalledTimes(1);
-    expect(String(fetchMock.mock.calls[0][0])).toContain("formspree.io");
+    expect(isRequestToHost(fetchMock.mock.calls[0], "formspree.io")).toBe(
+      true,
+    );
   });
 
   it("skips Formspree when the key is not configured", async () => {
@@ -116,7 +161,9 @@ describe("app/api/lost-luggage-notify/route POST", () => {
     const res = await POST(req);
     expect(res.status).toBe(200);
     expect(fetchMock).toHaveBeenCalledTimes(1);
-    expect(String(fetchMock.mock.calls[0][0])).toContain("api.telegram.org");
+    expect(isRequestToHost(fetchMock.mock.calls[0], "api.telegram.org")).toBe(
+      true,
+    );
   });
 
   it("logs a warning but still returns ok when a notifier fails", async () => {
@@ -192,6 +239,52 @@ describe("app/api/lost-luggage-notify/route POST", () => {
     const json = (await res.json()) as { ok: boolean };
     expect(json.ok).toBe(true);
     expect(fetchMock).not.toHaveBeenCalled();
+  });
+
+  it("returns ok without calling any service when Origin doesn't match the request host", async () => {
+    const fetchMock = vi.fn();
+    global.fetch = fetchMock as unknown as typeof fetch;
+
+    const POST = await createPostHandler();
+    const req = createRequest(basePayload, {
+      "x-forwarded-for": "203.0.113.13",
+      origin: "https://evil.example.com",
+    });
+
+    const res = await POST(req);
+    expect(res.status).toBe(200);
+    const json = (await res.json()) as { ok: boolean };
+    expect(json.ok).toBe(true);
+    expect(fetchMock).not.toHaveBeenCalled();
+  });
+
+  it("notifies as usual when Origin matches the request host", async () => {
+    const fetchMock = vi.fn().mockResolvedValue({ ok: true } as Response);
+    global.fetch = fetchMock as unknown as typeof fetch;
+
+    const POST = await createPostHandler();
+    const req = createRequest(basePayload, {
+      "x-forwarded-for": "203.0.113.14",
+      origin: TEST_ORIGIN,
+    });
+
+    const res = await POST(req);
+    expect(res.status).toBe(200);
+    expect(fetchMock).toHaveBeenCalledTimes(2);
+  });
+
+  it("notifies as usual when no Origin header is present (server-to-server)", async () => {
+    const fetchMock = vi.fn().mockResolvedValue({ ok: true } as Response);
+    global.fetch = fetchMock as unknown as typeof fetch;
+
+    const POST = await createPostHandler();
+    const req = createRequest(basePayload, {
+      "x-forwarded-for": "203.0.113.15",
+    });
+
+    const res = await POST(req);
+    expect(res.status).toBe(200);
+    expect(fetchMock).toHaveBeenCalledTimes(2);
   });
 
   it("returns 429 with Retry-After once the per-IP rate limit is exceeded", async () => {

--- a/test/unit/lost-luggage-notify-route.test.ts
+++ b/test/unit/lost-luggage-notify-route.test.ts
@@ -143,7 +143,7 @@ describe("app/api/lost-luggage-notify/route POST", () => {
     expect(warnSpy).toHaveBeenCalled();
   });
 
-  it("returns ok without calling any service on invalid input", async () => {
+  it("returns ok without calling any service when locale is not a valid type", async () => {
     const fetchMock = vi.fn();
     global.fetch = fetchMock as unknown as typeof fetch;
 
@@ -160,7 +160,41 @@ describe("app/api/lost-luggage-notify/route POST", () => {
     expect(fetchMock).not.toHaveBeenCalled();
   });
 
-  it("rate limits repeated requests from the same IP without erroring", async () => {
+  it("returns ok without calling any service when locale is not a supported locale", async () => {
+    const fetchMock = vi.fn();
+    global.fetch = fetchMock as unknown as typeof fetch;
+
+    const POST = await createPostHandler();
+    const req = createRequest(
+      { locale: "fr" },
+      { "x-forwarded-for": "203.0.113.10" },
+    );
+
+    const res = await POST(req);
+    expect(res.status).toBe(200);
+    const json = (await res.json()) as { ok: boolean };
+    expect(json.ok).toBe(true);
+    expect(fetchMock).not.toHaveBeenCalled();
+  });
+
+  it("returns ok without calling any service when referrer is not a valid URL", async () => {
+    const fetchMock = vi.fn();
+    global.fetch = fetchMock as unknown as typeof fetch;
+
+    const POST = await createPostHandler();
+    const req = createRequest(
+      { locale: "en", referrer: "not-a-url" },
+      { "x-forwarded-for": "203.0.113.11" },
+    );
+
+    const res = await POST(req);
+    expect(res.status).toBe(200);
+    const json = (await res.json()) as { ok: boolean };
+    expect(json.ok).toBe(true);
+    expect(fetchMock).not.toHaveBeenCalled();
+  });
+
+  it("returns 429 with Retry-After once the per-IP rate limit is exceeded", async () => {
     const fetchMock = vi.fn().mockResolvedValue({ ok: true } as Response);
     global.fetch = fetchMock as unknown as typeof fetch;
 
@@ -179,9 +213,10 @@ describe("app/api/lost-luggage-notify/route POST", () => {
     const blockedRes = await POST(
       createRequest(basePayload, { "x-forwarded-for": ip }),
     );
-    expect(blockedRes.status).toBe(200);
-    const blockedJson = (await blockedRes.json()) as { ok: boolean };
-    expect(blockedJson.ok).toBe(true);
+    expect(blockedRes.status).toBe(429);
+    expect(blockedRes.headers.get("Retry-After")).toBeDefined();
+    const blockedJson = (await blockedRes.json()) as { error: string };
+    expect(blockedJson.error.toLowerCase()).toContain("too many requests");
     // No additional external calls once rate-limited.
     expect(fetchMock.mock.calls.length).toBe(callsAfterFive);
   });

--- a/test/unit/lost-luggage-notify-route.test.ts
+++ b/test/unit/lost-luggage-notify-route.test.ts
@@ -241,6 +241,30 @@ describe("app/api/lost-luggage-notify/route POST", () => {
     expect(fetchMock).not.toHaveBeenCalled();
   });
 
+  it("does not consume the rate-limit quota for malformed payloads", async () => {
+    const fetchMock = vi.fn().mockResolvedValue({ ok: true } as Response);
+    global.fetch = fetchMock as unknown as typeof fetch;
+
+    const POST = await createPostHandler();
+    const ip = "198.51.100.30";
+
+    // Five malformed requests from the same IP...
+    for (let i = 0; i < 5; i += 1) {
+      const res = await POST(
+        createRequest({ locale: "fr" }, { "x-forwarded-for": ip }),
+      );
+      expect(res.status).toBe(200);
+    }
+    expect(fetchMock).not.toHaveBeenCalled();
+
+    // ...should not have burned the quota for a real, valid request after.
+    const validRes = await POST(
+      createRequest(basePayload, { "x-forwarded-for": ip }),
+    );
+    expect(validRes.status).toBe(200);
+    expect(fetchMock).toHaveBeenCalledTimes(2);
+  });
+
   it("returns ok without calling any service when Origin doesn't match the request host", async () => {
     const fetchMock = vi.fn();
     global.fetch = fetchMock as unknown as typeof fetch;

--- a/test/unit/lost-luggage-notify-route.test.ts
+++ b/test/unit/lost-luggage-notify-route.test.ts
@@ -1,0 +1,188 @@
+import type { NextRequest } from "next/server";
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+
+interface MockRequestInit {
+  json: () => Promise<unknown>;
+  headers?: Headers;
+}
+
+async function createPostHandler() {
+  // Reload module fresh for each test so env changes are picked up.
+  vi.resetModules();
+  const mod = await import("../../app/api/lost-luggage-notify/route");
+  return mod.POST as (req: NextRequest) => Promise<Response>;
+}
+
+function createRequest(body: unknown, headers?: Record<string, string>) {
+  const h = new Headers(headers);
+  const init: MockRequestInit = {
+    json: async () => body,
+    headers: h,
+  };
+
+  return init as unknown as NextRequest;
+}
+
+const basePayload = {
+  locale: "en",
+  referrer: "https://example.com/qr",
+};
+
+describe("app/api/lost-luggage-notify/route POST", () => {
+  const originalEnv = { ...process.env };
+
+  beforeEach(() => {
+    vi.restoreAllMocks();
+    process.env = { ...originalEnv };
+    process.env.TELEGRAM_BOT_TOKEN = "bot-token";
+    process.env.TELEGRAM_CHAT_ID = "chat-id";
+    process.env.NEXT_PUBLIC_FORMSPREE_KEY = "forms-key";
+  });
+
+  afterEach(() => {
+    process.env = { ...originalEnv };
+  });
+
+  it("notifies Telegram and Formspree and returns ok", async () => {
+    const fetchMock = vi.fn().mockResolvedValue({ ok: true } as Response);
+    global.fetch = fetchMock as unknown as typeof fetch;
+
+    const POST = await createPostHandler();
+    const req = createRequest(basePayload, {
+      "x-forwarded-for": "203.0.113.5",
+      "user-agent": "test-agent",
+      "x-vercel-ip-country": "ES",
+      "x-vercel-ip-city": "Madrid",
+    });
+
+    const res = await POST(req);
+    expect(res.status).toBe(200);
+    const json = (await res.json()) as { ok: boolean };
+    expect(json.ok).toBe(true);
+
+    expect(fetchMock).toHaveBeenCalledTimes(2);
+
+    const telegramCall = fetchMock.mock.calls.find((call) =>
+      String(call[0]).includes("api.telegram.org"),
+    );
+    expect(telegramCall).toBeDefined();
+    expect(String(telegramCall?.[0])).toContain("bot-token");
+    const telegramBody = JSON.parse(
+      (telegramCall?.[1] as { body: string }).body,
+    );
+    expect(telegramBody.chat_id).toBe("chat-id");
+    expect(telegramBody.text).toContain("Locale: en");
+    expect(telegramBody.text).toContain("Madrid, ES");
+    expect(telegramBody.text).toContain("https://example.com/qr");
+    expect(telegramBody.text).toContain("test-agent");
+
+    const formspreeCall = fetchMock.mock.calls.find((call) =>
+      String(call[0]).includes("formspree.io"),
+    );
+    expect(formspreeCall).toBeDefined();
+    expect(String(formspreeCall?.[0])).toContain("forms-key");
+  });
+
+  it("skips Telegram when credentials are not configured", async () => {
+    delete process.env.TELEGRAM_BOT_TOKEN;
+    delete process.env.TELEGRAM_CHAT_ID;
+
+    const fetchMock = vi.fn().mockResolvedValue({ ok: true } as Response);
+    global.fetch = fetchMock as unknown as typeof fetch;
+
+    const POST = await createPostHandler();
+    const req = createRequest(basePayload, {
+      "x-forwarded-for": "203.0.113.6",
+    });
+
+    const res = await POST(req);
+    expect(res.status).toBe(200);
+    // Only Formspree should have been called.
+    expect(fetchMock).toHaveBeenCalledTimes(1);
+    expect(String(fetchMock.mock.calls[0][0])).toContain("formspree.io");
+  });
+
+  it("skips Formspree when the key is not configured", async () => {
+    delete process.env.NEXT_PUBLIC_FORMSPREE_KEY;
+
+    const fetchMock = vi.fn().mockResolvedValue({ ok: true } as Response);
+    global.fetch = fetchMock as unknown as typeof fetch;
+
+    const POST = await createPostHandler();
+    const req = createRequest(basePayload, {
+      "x-forwarded-for": "203.0.113.7",
+    });
+
+    const res = await POST(req);
+    expect(res.status).toBe(200);
+    expect(fetchMock).toHaveBeenCalledTimes(1);
+    expect(String(fetchMock.mock.calls[0][0])).toContain("api.telegram.org");
+  });
+
+  it("logs a warning but still returns ok when a notifier fails", async () => {
+    const fetchMock = vi
+      .fn()
+      .mockResolvedValueOnce({ ok: false, status: 500 } as Response)
+      .mockResolvedValueOnce({ ok: true } as Response);
+    global.fetch = fetchMock as unknown as typeof fetch;
+
+    const POST = await createPostHandler();
+    const errorLogging = await import("../../lib/error-logging");
+    const warnSpy = vi
+      .spyOn(errorLogging, "logWarning")
+      .mockImplementation(() => {});
+
+    const req = createRequest(basePayload, {
+      "x-forwarded-for": "203.0.113.8",
+    });
+
+    const res = await POST(req);
+    expect(res.status).toBe(200);
+    const json = (await res.json()) as { ok: boolean };
+    expect(json.ok).toBe(true);
+    expect(warnSpy).toHaveBeenCalled();
+  });
+
+  it("returns ok without calling any service on invalid input", async () => {
+    const fetchMock = vi.fn();
+    global.fetch = fetchMock as unknown as typeof fetch;
+
+    const POST = await createPostHandler();
+    const req = createRequest(
+      { locale: 12345 },
+      { "x-forwarded-for": "203.0.113.9" },
+    );
+
+    const res = await POST(req);
+    expect(res.status).toBe(200);
+    const json = (await res.json()) as { ok: boolean };
+    expect(json.ok).toBe(true);
+    expect(fetchMock).not.toHaveBeenCalled();
+  });
+
+  it("rate limits repeated requests from the same IP without erroring", async () => {
+    const fetchMock = vi.fn().mockResolvedValue({ ok: true } as Response);
+    global.fetch = fetchMock as unknown as typeof fetch;
+
+    const POST = await createPostHandler();
+    const ip = "198.51.100.20";
+
+    for (let i = 0; i < 5; i += 1) {
+      const res = await POST(
+        createRequest(basePayload, { "x-forwarded-for": ip }),
+      );
+      expect(res.status).toBe(200);
+    }
+
+    const callsAfterFive = fetchMock.mock.calls.length;
+
+    const blockedRes = await POST(
+      createRequest(basePayload, { "x-forwarded-for": ip }),
+    );
+    expect(blockedRes.status).toBe(200);
+    const blockedJson = (await blockedRes.json()) as { ok: boolean };
+    expect(blockedJson.ok).toBe(true);
+    // No additional external calls once rate-limited.
+    expect(fetchMock.mock.calls.length).toBe(callsAfterFive);
+  });
+});

--- a/test/unit/lost-luggage-page.test.tsx
+++ b/test/unit/lost-luggage-page.test.tsx
@@ -1,0 +1,71 @@
+import { render, screen } from "@testing-library/react";
+import { afterEach, describe, expect, it, vi } from "vitest";
+
+vi.mock("../../app/components/LostLuggageNotifier", () => ({
+  LostLuggageNotifier: ({ locale }: { locale: string }) => (
+    <div data-testid="notifier" data-locale={locale} />
+  ),
+}));
+
+import LostLuggagePage, {
+  generateMetadata,
+} from "../../app/[lang]/lost-luggage/page";
+
+afterEach(() => {
+  vi.restoreAllMocks();
+});
+
+describe("LostLuggagePage", () => {
+  it("renders the English contact details and fires the notifier", async () => {
+    const ui = await LostLuggagePage({
+      params: Promise.resolve({ lang: "en" }),
+    });
+
+    render(ui);
+
+    expect(
+      screen.getByRole("heading", {
+        level: 1,
+        name: /you found my luggage/i,
+      }),
+    ).toBeInTheDocument();
+    expect(screen.getByRole("link", { name: /vicente@opa\.so/i })).toHaveAttribute(
+      "href",
+      "mailto:vicente@opa.so",
+    );
+    expect(
+      screen.getByRole("link", { name: /\+34 684 00 52 62/i }),
+    ).toHaveAttribute("href", "tel:+34684005262");
+    expect(
+      screen.getByRole("link", { name: /message on whatsapp/i }),
+    ).toHaveAttribute("href", "https://wa.me/34684005262");
+
+    const notifier = screen.getByTestId("notifier");
+    expect(notifier).toHaveAttribute("data-locale", "en");
+  });
+
+  it("renders the Spanish contact details", async () => {
+    const ui = await LostLuggagePage({
+      params: Promise.resolve({ lang: "es" }),
+    });
+
+    render(ui);
+
+    expect(
+      screen.getByRole("heading", {
+        level: 1,
+        name: /encontraste mi equipaje/i,
+      }),
+    ).toBeInTheDocument();
+    expect(screen.getByTestId("notifier")).toHaveAttribute(
+      "data-locale",
+      "es",
+    );
+  });
+
+  it("marks the page as noindex so it stays unlisted", async () => {
+    const metadata = await generateMetadata();
+
+    expect(metadata.robots).toMatchObject({ index: false, follow: false });
+  });
+});

--- a/test/unit/lost-luggage-redirect-page.test.tsx
+++ b/test/unit/lost-luggage-redirect-page.test.tsx
@@ -1,0 +1,55 @@
+import { afterEach, describe, expect, it, vi } from "vitest";
+
+const headersMock = vi.fn();
+const redirectMock = vi.fn((url: string) => {
+  throw new Error(`REDIRECT:${url}`);
+});
+
+vi.mock("next/headers", () => ({
+  headers: () => headersMock(),
+}));
+
+vi.mock("next/navigation", () => ({
+  redirect: (url: string) => redirectMock(url),
+}));
+
+function mockAcceptLanguage(value: string | null) {
+  headersMock.mockResolvedValue({
+    get: (key: string) => (key === "accept-language" ? value : null),
+  });
+}
+
+async function loadPage() {
+  vi.resetModules();
+  const mod = await import("../../app/lost-luggage/page");
+  return mod.default;
+}
+
+afterEach(() => {
+  vi.restoreAllMocks();
+  headersMock.mockReset();
+  redirectMock.mockClear();
+});
+
+describe("LostLuggageRedirectPage", () => {
+  it("redirects to the Spanish page when es is preferred", async () => {
+    mockAcceptLanguage("es-ES,es;q=0.9,en;q=0.8");
+    const Page = await loadPage();
+
+    await expect(Page()).rejects.toThrow("REDIRECT:/es/lost-luggage");
+  });
+
+  it("redirects to English by default when no header is present", async () => {
+    mockAcceptLanguage(null);
+    const Page = await loadPage();
+
+    await expect(Page()).rejects.toThrow("REDIRECT:/en/lost-luggage");
+  });
+
+  it("falls back to English for unsupported languages", async () => {
+    mockAcceptLanguage("fr-FR,fr;q=0.9");
+    const Page = await loadPage();
+
+    await expect(Page()).rejects.toThrow("REDIRECT:/en/lost-luggage");
+  });
+});


### PR DESCRIPTION
## Summary

- Adds a QR-code-only `/lost-luggage` page (en/es) with Vicente's contact info (email, phone, WhatsApp) for whoever finds a lost bag — not linked from nav/footer, `noindex`, and excluded from the sitemap.
- The no-locale `/lost-luggage` route detects `Accept-Language` and redirects into `/en/lost-luggage` or `/es/lost-luggage`, defaulting to English.
- Every real page view fires a best-effort, rate-limited notification (Telegram + Formspree) with timestamp, locale, referrer, user-agent, and approximate geo (from Vercel's built-in headers), so a real visit reaches Vicente directly.

## Related Issue

N/A — requested directly in chat, no tracked issue.

## Type of Change

- [x] `feat` — New feature or enhancement
- [ ] `fix` — Bug fix
- [ ] `chore` — Maintenance, dependencies, or configuration
- [ ] `docs` — Documentation only
- [ ] `refactor` — Code refactoring without behavior change
- [ ] `test` — Adding or updating tests

## Architecture Decision Record (ADR)

**Architecture Change?**

- [ ] Yes (add `architecture-change` label and link ADR above)
- [x] No — follows the existing content-page pattern (`ContentPageShell` + `loadContentPage` + markdown), and adds one new small API route following the existing `app/api/contact` pattern.

## Technical Governance Compliance

- [x] Complies with the supreme invariants in [Constitution](../docs/CONSTITUTION.md)
- [x] Follows [Engineering Standards](../docs/ENGINEERING_STANDARDS.md)
- [x] Follows [Architecture](../docs/ARCHITECTURE.md) guidelines
- [x] Follows [Technical Governance](https://vicenteopaso.com/technical-governance) principles
- [x] Aligns with the SDD (`/sdd.yaml`) or updates it in this PR
- [ ] Documentation updated in `docs/` (if applicable) — not applicable, no docs reference this unlisted page
- [ ] Component documentation added/updated (if applicable) — not applicable
- [ ] README updated (if behavior changes) — not applicable, no dev workflow changes

## AI Governance (if applicable)

> **Note**: If this PR includes AI-generated code, ensure compliance with AI governance requirements.

- [x] Reviewed [AI Guardrails](../docs/AI_GUARDRAILS.md) — Security constraints respected
- [x] Reviewed [Forbidden Patterns](../docs/FORBIDDEN_PATTERNS.md) — No anti-patterns introduced
- [x] Completed [Review Checklist](../docs/REVIEW_CHECKLIST.md) — All applicable items verified
- [x] Security controls maintained (Turnstile, rate limiting, input validation, HTML sanitization) — the notify route is rate-limited per IP and Zod-validates its input; no Turnstile needed since it takes no user-authored content
- [x] No secrets or credentials hard-coded — `TELEGRAM_BOT_TOKEN`/`TELEGRAM_CHAT_ID` are read from env, documented in `.env.example`, and the real values live only in the untracked `.env.local`
- [x] Accessibility standards maintained (WCAG 2.1 AA) — reuses the existing `markdownComponents`/`ContentPageShell` styling
- [x] Architecture boundaries respected (no cross-layer imports)

## Quality Checks

- [x] `pnpm lint` passes
- [x] `pnpm typecheck` passes
- [x] `pnpm test` passes with adequate coverage (see coverage report below)
- [ ] `pnpm test:e2e` passes (if UI/routing changes) — not run in this session; unit tests cover the new page/route/component directly
- [ ] Visual tests updated if UI changed (`pnpm test:visual:update`) — page reuses existing content-page styling, no new visual surface
- [x] Reviewed changes against [Code Review Checklist](../docs/REVIEW_CHECKLIST.md)

## CI/CD

- [x] All required checks pass (lint, typecheck, test, coverage, build, a11y, security, Lighthouse)

## AI Guardrails Compliance

> **Required for all code changes in `app/` or `lib/`**

- [x] Tests added/updated for code changes (unit, e2e, or visual) — `test/unit/lost-luggage-page.test.tsx`, `test/unit/lost-luggage-redirect-page.test.tsx`, `test/unit/lost-luggage-notify-route.test.ts`, `test/unit/lost-luggage-notifier.test.tsx`
- [x] Error handling verified and follows [Error Handling Guide](../docs/ERROR_HANDLING.md) — notify failures are caught, logged via `logWarning`, and never surface to the visitor
- [x] Accessibility verified (keyboard navigation, ARIA, focus management) — inherits from the shared markdown/content-page components already in use elsewhere
- [x] SEO impact assessed and metadata updated if needed — explicitly `noindex`/`nofollow` and excluded from the sitemap since this page is only reachable via a physical QR code
- [x] Security considerations reviewed (input validation, XSS prevention) — notify payload is Zod-validated; markdown content is static (author-controlled), not user input

## Additional Verification

- [ ] Cross-browser testing completed (if UI changes) — not performed
- [x] Performance impact considered (bundle size, Core Web Vitals) — statically generated page, one small client component that fires a fire-and-forget beacon
- [ ] Mobile responsiveness verified (if UI changes) — reuses existing responsive content-page layout, not independently re-verified

## Additional Notes

- Test plan verified locally during development: `/lost-luggage` redirects to `/en/lost-luggage` by default and to `/es/lost-luggage` with `Accept-Language: es`, falling back to English for unsupported languages; both localized pages render name/email/phone/WhatsApp correctly; `/api/lost-luggage-notify` returns 200 and successfully delivered two test Telegram notifications.
- `TELEGRAM_BOT_TOKEN` / `TELEGRAM_CHAT_ID` env vars have been added in Vercel by Vicente outside this PR.
- Unit tests caught a real bug during development: react-markdown's default URL sanitizer strips `tel:` links (only allows http(s)/mailto/irc(s)/xmpp), which silently emptied the phone link's `href`. Fixed with an explicit `urlTransform` override on this page.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
